### PR TITLE
VSCode: Formatting settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,4 @@
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
     "files.trimTrailingWhitespace": true,
-    },
 }


### PR DESCRIPTION
```json
{
    "files.insertFinalNewline": true,
    "files.trimFinalNewlines": true,
    "files.trimTrailingWhitespace": true,
    },
}
```

Ini adalah kesalahan penulisan file JSON, dimana bracket dibuka 1 kali dan ditutup 2 kali. Walaupun tampaknya VSCode dapat mentoleransi ketika load workspace setting yang ditetapkan, tetapi VSCode akan menampilkan error kita hendak ingin menambahkan aturan.

<details>
  <summary>Screenshot</summary>
  
  ![noname-crop](https://user-images.githubusercontent.com/1314456/147912243-da1b67f0-b71c-417b-bb5e-c3e3ab465ec0.png)
</details>

Perbaikan yang Saya ajukan adalah dengan menghapus kelebihan penutup bracket tersebut.