### PR TITLE
A: https://komikcastid.com/

### DIFF
--- a/src/advert/specific_block.txt
+++ b/src/advert/specific_block.txt
@@ -232,3 +232,5 @@
 ||yourjavascript.com/0653544211/lompatin.js
 ||yourjavascript.com/1411253239/itu-domino-popup-script.js
 ||yourjavascript.com/9422241923/iklan-popweb-goalcoid.js
+! html/image popups
+/^https?:\/\/.*\.(jpg|gif|png|php|svg|ico|js|txt)/$popup,domain=komikcastid.com


### PR DESCRIPTION
Block images popups at https://komikcastid.com/

Suggestion: Have a more generic filter where we could just add the domains where we can see the same behaviour.
`easylist/easylist_specific_block_popup.txt` - the filter is present in this list.

I couldn't find the same in here, so it's just a suggestion 😄 

Screenshot: 
<img width="553" alt="Screenshot 2022-02-07 at 13 12 28" src="https://user-images.githubusercontent.com/65717387/152785889-b5d7b0a3-c705-44ec-9215-3af1e63a5b01.png">

