### PR TITLE
A: https://gatsunime.org/

### DIFF
--- a/src/advert/adservers.txt
+++ b/src/advert/adservers.txt
@@ -89,6 +89,7 @@
 ||dewsburg.info^$third-party
 ||digiads.co.id^$popup
 ||digiads.co.id^$third-party
+||discordapp.com^$third-party
 ||doathair.com^$third-party
 ||domnovrek.com^$third-party
 ||e7393e33565ce805.com^$popup
@@ -247,6 +248,7 @@
 ||sumberiklan.com^$third-party
 ||suryaiklan.com^$third-party
 ||syndopop.com^$popup
+||taoyinbiacid.com^
 ||teliad.com^$third-party
 ||theclickers.net^$third-party
 ||tidnqztumpnk.com^$popup

--- a/src/advert/adservers.txt
+++ b/src/advert/adservers.txt
@@ -89,7 +89,6 @@
 ||dewsburg.info^$third-party
 ||digiads.co.id^$popup
 ||digiads.co.id^$third-party
-||discordapp.com^$third-party
 ||doathair.com^$third-party
 ||domnovrek.com^$third-party
 ||e7393e33565ce805.com^$popup

--- a/src/advert/specific_hide.txt
+++ b/src/advert/specific_hide.txt
@@ -150,7 +150,7 @@ cafecinema.cc,dramamu.net,lk21.world,sidrama.com###netkevin-overlay
 mangashiro.net###openpopunder
 viva.co.id###otp_ads
 detik.com###otp_banner
-drakorindo.best,layarkeren.site###ouibounce-modal
+drakorindo.best,gatsunime.org,layarkeren.site###ouibounce-modal
 kricom.id###overlay
 dunia21.me,dunia21.net,dunia21.org,dunia21.wtf###overlay-pop
 lihat.co.id###overlay[style="display: block;"]

--- a/src/advert/specific_hide.txt
+++ b/src/advert/specific_hide.txt
@@ -607,6 +607,7 @@ lk21c.fun##a[href^="https://rebrand.ly/"]
 awsubs.co##a[rel="nofollow"] > img[src*="bp.blogspot.com"]
 awsubs.co##a[rel="noopener"] > img[src*="bp.blogspot.com"]
 republika.co.id##a[style="width: 100%; height: 100%; display: block; position: fixed; z-index: 1"]
+gatsunime.org##a[target="_blank"][rel^="noopener noreferrer"] > img[src$=".gif"]
 bioskop168.co,bioskop168.online,bioskop168.pro##bioskop-kanan
 gigapurbalingga.net,kuyhaa-me.com##center
 nontonfilm88.com##center > table


### PR DESCRIPTION
Block adservers + Hide modal at https://gatsunime.org/

Screenshots: 
<img width="1099" alt="Screenshot 2022-02-10 at 08 32 55" src="https://user-images.githubusercontent.com/65717387/153359007-9f28145d-bd27-45d6-b4d4-d0b023b958ec.png">
<img width="1101" alt="Screenshot 2022-02-10 at 08 32 26" src="https://user-images.githubusercontent.com/65717387/153358949-f4b4e792-5ed1-4d90-a4ef-cb8bd66dfce5.png">


Maybe this filter can be moved to the specific block side, Discord is widely used within the pages.
On the other hand I've never seen this cdn before. If you think other webpages may crash we could go for: `||discordapp.com^$third-party,domain=gatsunime.org`
<img width="829" alt="Screenshot 2022-02-10 at 08 32 03" src="https://user-images.githubusercontent.com/65717387/153358896-59367a7d-b405-46ce-8022-3767567b687b.png">

