### PR TITLE
inews.id

### DIFF
--- a/src/advert/adservers.txt
+++ b/src/advert/adservers.txt
@@ -148,6 +148,7 @@
 ||jasaiklan.com^$third-party
 ||javaiklan.com^$third-party
 ||jillsclickcorner.com^$third-party
+||jjekxle.com^
 ||jnwsrqxrdqct.top^$popup
 ||juruiklan.com^$third-party
 ||kambingjantan.cc/*.gif$domain=manhwalands.xyz


### PR DESCRIPTION
https://www.inews.id/sport/all-sport/indonesia-turunkan-ganda-putra-terbaik-lawan-singapura-di-piala-thomas-2022-siapa-saja