### PR TITLE
GitHub Linguist support for adblock filters

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.template linguist-language=AdBlock linguist-detectable

--- a/src/.gitattributes
+++ b/src/.gitattributes
@@ -1,0 +1,1 @@
+*.txt linguist-language=AdBlock linguist-detectable


### PR DESCRIPTION
GitHub has been supporting adblock syntax highlight since September 5th. This PR will help you turn it on.