### PR TITLE
Sembunyikan placeholder iklan (Kompas+)

### DIFF
--- a/src/advert/specific_hide.txt
+++ b/src/advert/specific_hide.txt
@@ -733,3 +733,4 @@ animebatchs.com##img[width="720"][height="90"]
 satujiwa.org##table
 lk21.cc##tbody
 bioskop78.com##td:nth-of-type(3)
+kompas.com##.gate-kgplus


### PR DESCRIPTION
Telah hadir _placeholder_ iklan yang diblokir di situs Kompas, yang menawarkan Kompas+ untuk pelayanan tanpa iklan. PR ini seharusnya dapat menyembunyikannya.

Contoh: https://regional.kompas.com/read/2023/02/09/191008178/pak-jokowi-kami-sudah-lelah-belajar-pakai-lampu-minyak-tanah-tolong-kasih