### PR TITLE
M: Properly isolate separator for element hiding filters

### DIFF
--- a/tools/FOP.py
+++ b/tools/FOP.py
@@ -40,7 +40,7 @@ from urllib.parse import urlparse
 # Compile regular expressions to match important filter parts (derived from Wladimir Palant's Adblock Plus source code)
 ELEMENTDOMAINPATTERN = re.compile(r"^([^\/\*\|\@\"\!]*?)(#|\$)\@?\??\@?(#|\$)")
 FILTERDOMAINPATTERN = re.compile(r"(?:\$|\,)domain\=([^\,\s]+)$")
-ELEMENTPATTERN = re.compile(r"^([^\/\*\|\@\"\!]*?)(\$|##\@?\$|#\@?#?\+?)([^{]+)$")
+ELEMENTPATTERN = re.compile(r"^([^\/\*\|\@\"\!]*?)(\$|##\@?\$|#[\@\?]?#\+?)([^{]+)$")
 OPTIONPATTERN = re.compile(r"^(.*)\$(~?[\w\-]+(?:=[^,\s]+)?(?:,~?[\w\-]+(?:=[^,\s]+)?)*)$")
 
 # Compile regular expressions that match element tags and pseudo classes and strings and tree selectors; "@" indicates either the beginning or the end of a selector


### PR DESCRIPTION
The current version of FOP used does not properly isolate element hiding emulation filter separator (`#?#`). This pull request will fix that.

Related commit:
https://github.com/FiltersHeroes/ScriptsPlayground/commit/eed6d6094dc44cc2b29ba12f90acf3b698ba412f