### PR TITLE
M: Remove Adblock Plus' snippet filter file

### DIFF
--- a/src/advert/snippet_adblockplus.txt
+++ b/src/advert/snippet_adblockplus.txt
@@ -1,1 +1,0 @@
-! Snippet filters for Adblock Plus 3.3 (https://help.eyeo.com/adblockplus/snippet-filters-tutorial)


### PR DESCRIPTION
ABPIndo cannot introduce any snippet filter(s) to users, per ABP's documentation.

Reference:
https://help.adblockplus.org/hc/en-us/articles/1500002338501

This pull request fixes #413.