### PR TITLE
M: Revert previously wrong class filter paste

### DIFF
--- a/src/advert/specific_hide.txt
+++ b/src/advert/specific_hide.txt
@@ -764,10 +764,10 @@ layarkaca21.*###fbbanner
 layarkaca21.*###hbanner
 layarkaca21.*###pbanner
 layarkaca21.*###ptbanner
-oploverz.*###.kln
 oploverz.*###teaser1
 oploverz.*###teaser2
 oploverz.*###teaser3
+oploverz.*##.kln
 samehadaku.*###floatbottom
 samehadaku.*###floatcenter
 samehadaku.*##.ads


### PR DESCRIPTION
A mistake happened on a previous attempt to assign a class filter to a wildcard TLD, resulting in no element being matched. This pull request will fix that.

Related commit:
https://github.com/ABPindo/indonesianadblockrules/commit/09b6bd84cf04097e323ed0e8309f4f6a78d85024