### PR TITLE
M: Improve FOP

### DIFF
--- a/tools/FOP.py
+++ b/tools/FOP.py
@@ -40,7 +40,7 @@ from urllib.parse import urlparse
 # Compile regular expressions to match important filter parts (derived from Wladimir Palant's Adblock Plus source code)
 ELEMENTDOMAINPATTERN = re.compile(r"^([^\/\*\|\@\"\!]*?)(#|\$)\@?\??\@?(#|\$)")
 FILTERDOMAINPATTERN = re.compile(r"(?:\$|\,)domain\=([^\,\s]+)$")
-ELEMENTPATTERN = re.compile(r"^([^\/\*\|\@\"\!]*?)(\$|##\@?\$|#[\@\?]?#\+?)([^{]+)$")
+ELEMENTPATTERN = re.compile(r"^([^\/\*\|\@\"\!]*?)(\$\@?\$|##\@?\$|#[\@\?]?#\+?)([^{]+)$")
 OPTIONPATTERN = re.compile(r"^(.*)\$(~?[\w\-]+(?:=[^,\s]+)?(?:,~?[\w\-]+(?:=[^,\s]+)?)*)$")
 
 # Compile regular expressions that match element tags and pseudo classes and strings and tree selectors; "@" indicates either the beginning or the end of a selector

--- a/tools/FOP.py
+++ b/tools/FOP.py
@@ -221,7 +221,7 @@ def fopsort (filename):
                 uncombinedFilters = sorted(set(section), key = lambda rule: re.sub(ELEMENTDOMAINPATTERN, "", rule))
                 outputfile.write("{filters}\n".format(filters = "\n".join(combinefilters(uncombinedFilters, ELEMENTDOMAINPATTERN, ","))))
             else:
-                uncombinedFilters = sorted(set(section), key = str.lower)
+                uncombinedFilters = sorted(sorted(set(section)), key = str.lower)
                 outputfile.write("{filters}\n".format(filters = "\n".join(combinefilters(uncombinedFilters, FILTERDOMAINPATTERN, "|"))))
 
         for line in inputfile:


### PR DESCRIPTION
The current version of FOP being used has two problems.

1. The regex used to identify element hiding filters will also match with generic network filter that uses rule modifiers. This causes the first filter section in `adult_general_block.txt` to be sorted as if it contains element hiding filters, even though it clearly does not.  This pull request will revise the regex being used.

2. The sorting algorithm used to sort network filters is unstable due to the use of `set()` and `str.lower`. This causes past commits [[1]](https://github.com/ABPindo/indonesianadblockrules/commit/460fd195c5ba89101ff3884d5b46d27b02147abf)[[2]](https://github.com/ABPindo/indonesianadblockrules/commit/2c7648577f8454f37760d39d5591ca6e1ab1cfc5)[[3]](https://github.com/ABPindo/indonesianadblockrules/commit/e7749dc8d55c7ccd702037e2089e4ff6ec16b8fa) to exhibit weird diff where two network filters that only differ in capitalisation will trade places from time to time. Such diff behaviour will make it harder to trace filters' history in the future. This pull request will stabilise the sorting algorithm being used.
   
   Even though one more sorting is performed due to this fix, any significant impact in performance should not be felt in modern machines. This is due to the fact that
   1. most of the time, we are sorting almost-correctly-sorted collections, and
   2. most of the time spent when executing this script happens during the execution of `filtertidy()` and `elementtidy()`, which can be shown using simple profiling methods.