### PR TITLE
A: detik.com - .sisip_video_ds

### DIFF
--- a/src/advert/specific_hide.txt
+++ b/src/advert/specific_hide.txt
@@ -805,3 +805,4 @@ tokopedia.com#?#section[data-unify="Card"]:-abp-has([href^="https://ta.tokopedia
 satujiwa.org##table
 lk21.cc##tbody
 bioskop78.com##td:nth-of-type(3)
+detik.com##.sisip_video_ds


### PR DESCRIPTION
Unrelated topic video ad at the end of articles, autoplaying when whole video is visible in viewport.
The video ad uses an `iframe` and that `iframe` is contained inside `div.sisip-video-ds`.
Title of the video ad does not have a unique selector so nothing can be done about it.

| before | after |
| --- | --- |
| ![image](https://github.com/ABPindo/indonesianadblockrules/assets/58775678/91f67c76-3cfa-4abb-8306-cf6522339203) | ![image](https://github.com/ABPindo/indonesianadblockrules/assets/58775678/54c12284-4829-40d3-8772-f9faa02e59a7) |