### PR TITLE
tribunnews.com - recommended next article slide banner

### DIFF
--- a/src/annoyances.txt
+++ b/src/annoyances.txt
@@ -11,3 +11,5 @@ pinhome.id##.style_stickyBannerDesktop__GLF3I
 kompas.com##.gate-kgplus
 ! kompas.com - kgnow embedded video
 kompas.com##.kgnw-player
+! tribunnews.com - recommended next article slide banner
+tribunnews.com##.desk-bannerslide


### PR DESCRIPTION
Full URLs:https://www.tribunnews.com/nasional/2025/05/22/bos-sritex-iwan-setiawan-lukminto-ditahan-di-rutan-salemba-diduga-rugikan-negara-hampir-rp-700-m?page=all

![image](https://github.com/user-attachments/assets/fef1e9a7-7a13-4ed6-8ee1-7de64c6eae11)

`tribunnews.com##.desk-bannerslide`