### PR TITLE
Hapus `kompas.com##.video-box-wrap` dari filter utama

### DIFF
--- a/src/advert/specific_hide.txt
+++ b/src/advert/specific_hide.txt
@@ -859,7 +859,6 @@ grid.id##.top_banner-wrapper
 beritasatu.com,jakartaglobe.id##.underlay-ad
 beritasatu.com,investor.id##.underlay-ad-text-box
 mosaikislam.com##.urutan_artikel
-kompas.com##.video-box-wrap
 mydramalist.com##.vip-info
 bacasaja.id##.w-100.gbrNews
 marketeers.com##.w-\[300px\]


### PR DESCRIPTION
### Tujuan
Mengusulkan untuk menghapus `kompas.com##.video-box-wrap` dari filter utama ABPindo.

### Latar Belakang
1. https://github.com/ABPindo/indonesianadblockrules/issues/790, dijelaskan bahwa filter tersebut secara tidak sengaja menghapus video, dimana video tersebut merupakan konten utama dari halaman yang bersangkutan.

    https://video.kompas.com/watch/1853962/gaya-trump-saat-gubernur-california-menyerang-soal-kerusuhan-imigran-la?accountid=9262bf2590d558736cac4fff7978fcb1&domain_referral=kompascom&source=KOMPASCOM&position=detail_sidebar__thumbnail_1
    
   ![image](https://github.com/user-attachments/assets/2b2b40aa-5977-4ec2-a611-6eecac23f68e)


2. 
    > `kompas.com##.video-box-wrap` This rule is from ABPindo_extended, not in default lists.
    > https://github.com/ABPindo/indonesianadblockrules/issues/790#issuecomment-2971906552

    Dari penjelasan di atas, tampaknya saat ini filter tersebut dimaksudkan untuk tidak berada di filter utama ABPindo.
