### PR TITLE
fix typo - fortuneidn.com

### DIFF
--- a/src/advert/specific_hide.txt
+++ b/src/advert/specific_hide.txt
@@ -1028,7 +1028,7 @@ gridoto.com##div.ads__side
 fortuneidn.com,ggwp.id,idntimes.com,popbela.com,popmama.com###IDN_MR1-wrapper
 fortuneidn.com,ggwp.id,idntimes.com,popbela.com,popmama.com###IDN_MR2-wrapper
 idntimes.com###ads-infeed
-fortuneidn,fortuneidn.com,ggwp.id,idntimes.com,popbela.com,popmama.com##.css-13bgxac
+fortuneidn.com,ggwp.id,idntimes.com,popbela.com,popmama.com##.css-13bgxac
 fortuneidn.com,ggwp.id,idntimes.com,popbela.com,popmama.com##.css-1614bu0
 fortuneidn.com,ggwp.id,idntimes.com,popbela.com,popmama.com##.css-172jeyh
 fortuneidn.com,ggwp.id,idntimes.com,popbela.com,popmama.com##.css-1e66tux


### PR DESCRIPTION
https://github.com/ABPindo/indonesianadblockrules/blob/0e368da18428176fb589d1a7d9f2da3aaa961aeb/src/advert/specific_hide.txt#L1031

Menghapus domain yang dianggap typo (`fortuneidn`). Saat melihat filter yang sudah ada, cukup aman untuk dikatakan `fortuneidn` adalah `fortuneidn.com`.

Karena `fortuneidn.com` sudah ada, perubahan ini mengusulkan untuk menghapus `fortuneidn`.