### PR TITLE
IDN Networks - remove redundant

### DIFF
--- a/src/advert/specific_hide.txt
+++ b/src/advert/specific_hide.txt
@@ -72,8 +72,6 @@ oploverz.*###teaser1
 oploverz.*###teaser2
 oploverz.*###teaser3
 oploverz.*##.kln
-popmama.com##div#ads-infeed.css-1sg3kbb:nth-of-type(2)
-popmama.com##div#ads-infeed.css-1sg3kbb:nth-of-type(9)
 rebahin21.*###floating-banner
 rebahin21.*###rebahin-banner
 samehadaku.*###floatbottom
@@ -1048,6 +1046,8 @@ idntimes.com##[id^="IDN_Leaderboard"]
 fortuneidn.com,ggwp.id,idntimes.com,popbela.com,popmama.com##[id^="wrapper-IDN_MegaBillboard"]
 fortuneidn.com,ggwp.id,idntimes.com,popbela.com,popmama.com##div#ads-infeed.css-1sg3kbb
 fortuneidn.com,ggwp.id,idntimes.com,popbela.com,popmama.com##div#ads-infeed.css-6aejgs
+popmama.com##div#ads-infeed.css-1sg3kbb:nth-of-type(2)
+popmama.com##div#ads-infeed.css-1sg3kbb:nth-of-type(9)
 ! ABP-specific filters
 tokopedia.com#?#.product-card:has(span:-abp-contains(/^Ad$/))
 cari.com.my#?#center:-abp-contains(ADVERTISEMENT)

--- a/src/advert/specific_hide.txt
+++ b/src/advert/specific_hide.txt
@@ -1044,10 +1044,10 @@ idntimes.com##[id^="IDN_Billboard"]
 idntimes.com##[id^="IDN_InArticle"]
 idntimes.com##[id^="IDN_Leaderboard"]
 fortuneidn.com,ggwp.id,idntimes.com,popbela.com,popmama.com##[id^="wrapper-IDN_MegaBillboard"]
-fortuneidn.com,ggwp.id,idntimes.com,popbela.com,popmama.com##div#ads-infeed.css-1sg3kbb
-fortuneidn.com,ggwp.id,idntimes.com,popbela.com,popmama.com##div#ads-infeed.css-6aejgs
-popmama.com##div#ads-infeed.css-1sg3kbb:nth-of-type(2)
-popmama.com##div#ads-infeed.css-1sg3kbb:nth-of-type(9)
+fortuneidn.com,ggwp.id,idntimes.com,popbela.com,popmama.com##div#ads-infeed
+fortuneidn.com,ggwp.id,idntimes.com,popbela.com,popmama.com##div#ads-infeed
+popmama.com##div#ads-infeed
+popmama.com##div#ads-infeed
 ! ABP-specific filters
 tokopedia.com#?#.product-card:has(span:-abp-contains(/^Ad$/))
 cari.com.my#?#center:-abp-contains(ADVERTISEMENT)

--- a/src/advert/specific_hide.txt
+++ b/src/advert/specific_hide.txt
@@ -1045,9 +1045,6 @@ idntimes.com##[id^="IDN_InArticle"]
 idntimes.com##[id^="IDN_Leaderboard"]
 fortuneidn.com,ggwp.id,idntimes.com,popbela.com,popmama.com##[id^="wrapper-IDN_MegaBillboard"]
 fortuneidn.com,ggwp.id,idntimes.com,popbela.com,popmama.com##div#ads-infeed
-fortuneidn.com,ggwp.id,idntimes.com,popbela.com,popmama.com##div#ads-infeed
-popmama.com##div#ads-infeed
-popmama.com##div#ads-infeed
 ! ABP-specific filters
 tokopedia.com#?#.product-card:has(span:-abp-contains(/^Ad$/))
 cari.com.my#?#center:-abp-contains(ADVERTISEMENT)


### PR DESCRIPTION
Filter yang terdampak saat PR ini dibuat

```adblock
fortuneidn.com,ggwp.id,idntimes.com,popbela.com,popmama.com##div#ads-infeed.css-1sg3kbb
fortuneidn.com,ggwp.id,idntimes.com,popbela.com,popmama.com##div#ads-infeed.css-6aejgs
popmama.com##div#ads-infeed.css-1sg3kbb:nth-of-type(2)
popmama.com##div#ads-infeed.css-1sg3kbb:nth-of-type(9)
```

#### Commit 1

Commit pertama memindahkan `popmama.com##div#ads-infeed.css-1sg3kbb:nth-of-type(2)` dan `popmama.com##div#ads-infeed.css-1sg3kbb:nth-of-type(9)` ke dalam ruang lingkup `IDN Networks` agar FOP bisa membersihkannya.

#### Commit 2

Karena konteksnya memblokir element yang mengandung ID `ads-infeed` pada element `div`, dimana umumnya dianggap cukup aman tanpa embel-embel, saya membuang filter cosmetic yang tidak diperlukan menjadi

```adblock
fortuneidn.com,ggwp.id,idntimes.com,popbela.com,popmama.com##div#ads-infeed
fortuneidn.com,ggwp.id,idntimes.com,popbela.com,popmama.com##div#ads-infeed
popmama.com##div#ads-infeed
popmama.com##div#ads-infeed
```

#### Commit 3

Menjalankan FOP untuk menyatukannya.