### PR TITLE
vscode: Memperbaiki versi yang dianggap tidak valid

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,6 +1,6 @@
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558 for the documentation about the tasks.json format
-    "version": "2.0.1",
+    "version": "2.0.0",
     "tasks": [
         {
             "label": "FOP",


### PR DESCRIPTION
Sebelum PR digabungkan, versi saat ini adalah `2.0.1`.

Masalahnya versi `2.0.1` dinggap tidak valid. Untuk menghilangkan error tersebut, saya menggantinya ke versi yang disarankan oleh vscode itu sendiri, yaitu `2.0.0`.

### Sebelum
![image](https://github.com/user-attachments/assets/4a19614f-b86b-4ab9-9ad3-ad2cb527987b)

### Sesudah
![image](https://github.com/user-attachments/assets/651a56da-d11f-4dc3-86a0-ad924ba4cd0a)



