### PR TITLE
Remove `beritasatu.com##.py-1` filter

### DIFF
--- a/src/advert/specific_hide.txt
+++ b/src/advert/specific_hide.txt
@@ -14,7 +14,6 @@ anoboy.*##[href^="https://bit.ly/"]
 baladfilm.*###floating_banner_top1
 baladfilm.*##.inner-floatbanner-bottom
 baladfilm.*##[href^="https://bit.ly/"]
-beritasatu.com##.py-1
 bioskopkeren.*###headads
 bioskopkeren.*###ptbanner
 bioskopkeren.*###top-banner


### PR DESCRIPTION
### Tujuan
Menghapus `beritasatu.com##.py-1` dari filter utama ABPindo.

### Latar Belakang
https://www.beritasatu.com/sport/2897911/start-dari-posisi-kelima-dan-ticktum-juara-jakarta-e-prix-2025

Filter `beritasatu.com##.py-1` yang diletakkan pada filter utama membuat ABPindo secara tidak sengaja menghapus daftar tag di halaman terkait yang mungkin dianggap sebagai Annoyance.

![image](https://github.com/user-attachments/assets/fcb3d216-7f7d-4ac5-b457-06434bf8f34d)
