### PR TITLE
Membersihkan dan menata ulang filter `.ads`

### DIFF
--- a/src/advert/specific_hide.txt
+++ b/src/advert/specific_hide.txt
@@ -450,7 +450,7 @@ kompas.tv##.alert
 indoxtream.com##.aligncenter
 palingseru.com##.alignnone.size-large.wp-image-458
 serialmovieislami.com##.alignnormal
-terasjakarta.id##.animated.ads
+terasjakarta.id##.ads
 autonetmagz.com##.anm__flying--ads-holder
 jpnn.com##.ans-300x250
 kurazone.net##.anuads
@@ -579,7 +579,7 @@ hrv.okestream365.xyz##.clappr-watermark
 sindonews.com##.clear.size-wide-custom.dummy
 filmku.net##.clearfix.act2-970x90:nth-of-type(1)
 filmku.net##.clearfix.act2-970x90:nth-of-type(3)
-arahpandang.com,aspirasiku.id,bandunginsider.com##.clearfix.mt3.ads
+arahpandang.com,aspirasiku.id,bandunginsider.com##.ads
 tempo.co##.closebanner1
 tempo.co##.closebanner2
 bolasport.com##.cls-composite

--- a/src/advert/specific_hide.txt
+++ b/src/advert/specific_hide.txt
@@ -362,12 +362,17 @@ terkini.id##.adbox
 bharian.com.my##.adbtm
 file.rocks##.add
 serialmovieislami.com##.adore-adver
-192.99.70.18,95.216.163.177,akurat.co,arahpandang.com,aspirasiku.id,ayobandung.com,ayojakarta.com,bandunginsider.com,dapurpacu.com,download-lagu-mp3.com,duniafilm21.com,embed.dramanices.com,gridoto.com,harianjogja.com,hops.id,jatimnetwork.com,jawapos.com,k-vid.net,katadata.co.id,kilat.com,kompas.com,koran-jakarta.com,masagipedia.com,miyanime.site,okezone.com,otakuindo.net,pikiran-rakyat.com,rejogja.co.id,republika.co.id,smallencode.com,tempo.co,terasjakarta.id,timenews.co.id,www.melintas.id,zonajakarta.com##.ads
+192.99.70.18,95.216.163.177,akurat.co,ayobandung.com,ayojakarta.com,dapurpacu.com,download-lagu-mp3.com,duniafilm21.com,embed.dramanices.com,gridoto.com,harianjogja.com,hops.id,jatimnetwork.com,jawapos.com,k-vid.net,katadata.co.id,kompas.com,koran-jakarta.com,masagipedia.com,miyanime.site,okezone.com,otakuindo.net,pikiran-rakyat.com,republika.co.id,smallencode.com,tempo.co,timenews.co.id,www.melintas.id##.ads
 arahpandang.com##.ads--stick-parent
 arahpandang.com##.ads--stick-parent-250px
 kilat.com,zonajakarta.com##.ads--stick-parent-400px
-rejogja.co.id,republika.co.id##.ads-120__left
-rejogja.co.id,republika.co.id##.ads-120__right
+kilat.com,zonajakarta.com##.ads
+republika.co.id##.ads-120__left
+rejogja.co.id##.ads-120__left
+rejogja.co.id##.ads
+republika.co.id##.ads-120__right
+rejogja.co.id##.ads-120__right
+rejogja.co.id##.ads
 republika.co.id##.ads-160
 republika.co.id##.ads-160-600
 republika.co.id##.ads-300-video
@@ -401,7 +406,9 @@ drakorasia.us##.ads728-slot-panjang
 kompas.com##.adsMR1Lipsus1
 marketeers.com##.adsMarketeers
 inews.id##.adsPlacement
-rejogja.co.id,republika.co.id##.ads_160x600
+republika.co.id##.ads_160x600
+rejogja.co.id##.ads_160x600
+rejogja.co.id##.ads
 republika.co.id##.ads_970x250
 bolasport.com,gridoto.com,motorplus-online.com##.ads__boxr
 poskota.co.id##.ads__min-h-\[250px\]
@@ -443,6 +450,7 @@ kompas.tv##.alert
 indoxtream.com##.aligncenter
 palingseru.com##.alignnone.size-large.wp-image-458
 serialmovieislami.com##.alignnormal
+terasjakarta.id##.ads
 autonetmagz.com##.anm__flying--ads-holder
 jpnn.com##.ans-300x250
 kurazone.net##.anuads
@@ -571,6 +579,7 @@ hrv.okestream365.xyz##.clappr-watermark
 sindonews.com##.clear.size-wide-custom.dummy
 filmku.net##.clearfix.act2-970x90:nth-of-type(1)
 filmku.net##.clearfix.act2-970x90:nth-of-type(3)
+arahpandang.com,aspirasiku.id,bandunginsider.com##.ads
 tempo.co##.closebanner1
 tempo.co##.closebanner2
 bolasport.com##.cls-composite

--- a/src/advert/specific_hide.txt
+++ b/src/advert/specific_hide.txt
@@ -362,17 +362,12 @@ terkini.id##.adbox
 bharian.com.my##.adbtm
 file.rocks##.add
 serialmovieislami.com##.adore-adver
-192.99.70.18,95.216.163.177,akurat.co,ayobandung.com,ayojakarta.com,dapurpacu.com,download-lagu-mp3.com,duniafilm21.com,embed.dramanices.com,gridoto.com,harianjogja.com,hops.id,jatimnetwork.com,jawapos.com,k-vid.net,katadata.co.id,kompas.com,koran-jakarta.com,masagipedia.com,miyanime.site,okezone.com,otakuindo.net,pikiran-rakyat.com,republika.co.id,smallencode.com,tempo.co,timenews.co.id,www.melintas.id##.ads
+192.99.70.18,95.216.163.177,akurat.co,arahpandang.com,aspirasiku.id,ayobandung.com,ayojakarta.com,bandunginsider.com,dapurpacu.com,download-lagu-mp3.com,duniafilm21.com,embed.dramanices.com,gridoto.com,harianjogja.com,hops.id,jatimnetwork.com,jawapos.com,k-vid.net,katadata.co.id,kilat.com,kompas.com,koran-jakarta.com,masagipedia.com,miyanime.site,okezone.com,otakuindo.net,pikiran-rakyat.com,rejogja.co.id,republika.co.id,smallencode.com,tempo.co,terasjakarta.id,timenews.co.id,www.melintas.id,zonajakarta.com##.ads
 arahpandang.com##.ads--stick-parent
 arahpandang.com##.ads--stick-parent-250px
 kilat.com,zonajakarta.com##.ads--stick-parent-400px
-kilat.com,zonajakarta.com##.ads
-republika.co.id##.ads-120__left
-rejogja.co.id##.ads-120__left
-rejogja.co.id##.ads
-republika.co.id##.ads-120__right
-rejogja.co.id##.ads-120__right
-rejogja.co.id##.ads
+rejogja.co.id,republika.co.id##.ads-120__left
+rejogja.co.id,republika.co.id##.ads-120__right
 republika.co.id##.ads-160
 republika.co.id##.ads-160-600
 republika.co.id##.ads-300-video
@@ -406,9 +401,7 @@ drakorasia.us##.ads728-slot-panjang
 kompas.com##.adsMR1Lipsus1
 marketeers.com##.adsMarketeers
 inews.id##.adsPlacement
-republika.co.id##.ads_160x600
-rejogja.co.id##.ads_160x600
-rejogja.co.id##.ads
+rejogja.co.id,republika.co.id##.ads_160x600
 republika.co.id##.ads_970x250
 bolasport.com,gridoto.com,motorplus-online.com##.ads__boxr
 poskota.co.id##.ads__min-h-\[250px\]
@@ -450,7 +443,6 @@ kompas.tv##.alert
 indoxtream.com##.aligncenter
 palingseru.com##.alignnone.size-large.wp-image-458
 serialmovieislami.com##.alignnormal
-terasjakarta.id##.ads
 autonetmagz.com##.anm__flying--ads-holder
 jpnn.com##.ans-300x250
 kurazone.net##.anuads
@@ -579,7 +571,6 @@ hrv.okestream365.xyz##.clappr-watermark
 sindonews.com##.clear.size-wide-custom.dummy
 filmku.net##.clearfix.act2-970x90:nth-of-type(1)
 filmku.net##.clearfix.act2-970x90:nth-of-type(3)
-arahpandang.com,aspirasiku.id,bandunginsider.com##.ads
 tempo.co##.closebanner1
 tempo.co##.closebanner2
 bolasport.com##.cls-composite

--- a/src/advert/specific_hide.txt
+++ b/src/advert/specific_hide.txt
@@ -365,7 +365,8 @@ serialmovieislami.com##.adore-adver
 192.99.70.18,95.216.163.177,akurat.co,ayobandung.com,ayojakarta.com,dapurpacu.com,download-lagu-mp3.com,duniafilm21.com,embed.dramanices.com,gridoto.com,harianjogja.com,hops.id,jatimnetwork.com,jawapos.com,k-vid.net,katadata.co.id,kompas.com,koran-jakarta.com,masagipedia.com,miyanime.site,okezone.com,otakuindo.net,pikiran-rakyat.com,republika.co.id,smallencode.com,tempo.co,timenews.co.id,www.melintas.id##.ads
 arahpandang.com##.ads--stick-parent
 arahpandang.com##.ads--stick-parent-250px
-kilat.com,zonajakarta.com##.ads--stick-parent-400px.clearfix.mt3.ads
+kilat.com,zonajakarta.com##.ads--stick-parent-400px
+kilat.com,zonajakarta.com##.ads
 republika.co.id##.ads-120__left
 rejogja.co.id##.ads-120__left
 rejogja.co.id##.ads

--- a/src/advert/specific_hide.txt
+++ b/src/advert/specific_hide.txt
@@ -367,9 +367,11 @@ arahpandang.com##.ads--stick-parent
 arahpandang.com##.ads--stick-parent-250px
 kilat.com,zonajakarta.com##.ads--stick-parent-400px.clearfix.mt3.ads
 republika.co.id##.ads-120__left
-rejogja.co.id##.ads-120__left.ads
+rejogja.co.id##.ads-120__left
+rejogja.co.id##.ads
 republika.co.id##.ads-120__right
-rejogja.co.id##.ads-120__right.ads
+rejogja.co.id##.ads-120__right
+rejogja.co.id##.ads
 republika.co.id##.ads-160
 republika.co.id##.ads-160-600
 republika.co.id##.ads-300-video
@@ -404,7 +406,8 @@ kompas.com##.adsMR1Lipsus1
 marketeers.com##.adsMarketeers
 inews.id##.adsPlacement
 republika.co.id##.ads_160x600
-rejogja.co.id##.ads_160x600.ads
+rejogja.co.id##.ads_160x600
+rejogja.co.id##.ads
 republika.co.id##.ads_970x250
 bolasport.com,gridoto.com,motorplus-online.com##.ads__boxr
 poskota.co.id##.ads__min-h-\[250px\]


### PR DESCRIPTION
Filter yang terdampak

```adblock
! Filter akan dipecah
rejogja.co.id##.ads-120__left.ads
rejogja.co.id##.ads-120__right.ads
rejogja.co.id##.ads_160x600.ads

! Filter akan dipecah dan dibersihkan dari tag yang tidak diperlukan
kilat.com,zonajakarta.com##.ads--stick-parent-400px.clearfix.mt3.ads

! Hanya dibersihkan
terasjakarta.id##.animated.ads
arahpandang.com,aspirasiku.id,bandunginsider.com##.clearfix.mt3.ads
```

Hasilnya akhirnya dapat dilihat di https://github.com/ABPindo/indonesianadblockrules/commit/353d000d7655875055e10080bfea48237e15dcd1 , ada cukup banyak filter yang dapat digabungkan oleh FOP.

Agar mudah untuk direview, Saya membaginya menjadi 3 commit dan membiarkan Anda atau system yang menjalankan FOP.