### PR TITLE
A: kingbokep.media - block popup/overlay ads and Telegram floating button

### DIFF
--- a/src/adult/adult_specific_hide.txt
+++ b/src/adult/adult_specific_hide.txt
@@ -109,6 +109,7 @@ bokepvir.*##[href="https://bkpv.online/reffbokepvir"]
 nekopoi.*##[href^="https://monetag.com/"]
 pemersatu.*##[role="advertisement"]
 kingbokep.*##[style^="height:"]:has(> img)
+kingbokep.*##a[href^="https://m.teknolur.eu.org/tele"]
 doujindesu.tv##a[href][target="_blank"] > img
 semprot.com,semprotku.com##a[href^="http://bit.ly/"]
 nokephub.com##a[href^="https://genec77.space/"]

--- a/src/adult/adult_thirdparty.txt
+++ b/src/adult/adult_thirdparty.txt
@@ -190,3 +190,6 @@
 ||wigobet.com^$third-party
 ||xjudi.com^$third-party
 ||yourpokercash.com^$third-party
+||url.getandplay.web.id^$third-party
+||shortbioo.com^$third-party
+||m.teknolur.eu.org^$popup,third-party


### PR DESCRIPTION
Fixes #1077

## Changes

- Block external ad script from url.getandplay.web.id (loads popup/overlay ads)
- Block shortbioo.com banner links
- Block m.teknolur.eu.org popups
- Hide Telegram floating button on kingbokep.media

## Analysis

From the page source at https://kingbokep.media/bokep-indo/2-7847/savira-gunawan:

1. The embed script at play.simplepaste.site/embed loads url.getandplay.web.id/all.js which injects popup/overlay ads
2. A Telegram floating button is dynamically created from m.teknolur.eu.org/tele
3. Existing filters for #floating-top and #floating-bottom already cover the static banner ads

## Testing

- AGLint passes on both modified files
- Filters use standard Adblock Plus syntax, compatible with uBlock Origin