### PR TITLE
chore: improve VSCode tasks for contributor workflow

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,26 +2,68 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "FOP: Sort src/",
+            "label": "Lint: AGLint",
             "type": "shell",
-            "command": "fop -n src/",
-            "detail": "Run Filter Orderer and Preener (Rust) on src/."
+            "command": "npm run lint",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "detail": "Run AGLint on all src/ filter files.",
+            "problemMatcher": []
+        },
+        {
+            "label": "Lint: Duplicates",
+            "type": "shell",
+            "command": "npm run check:duplicates",
+            "detail": "Detect duplicate rules across src/ files.",
+            "problemMatcher": []
+        },
+        {
+            "label": "Check: Lint + Build",
+            "type": "shell",
+            "command": "npm run check",
+            "detail": "Run AGLint then build all subscriptions (full validation).",
+            "problemMatcher": []
         },
         {
             "label": "Build: All subscriptions",
             "type": "shell",
-            "command": "bash build.sh",
+            "command": "npm run build",
             "group": {
                 "kind": "build",
                 "isDefault": true
             },
-            "detail": "Build all filter subscriptions locally."
+            "detail": "Build all ABP + DNS filter subscriptions.",
+            "problemMatcher": []
         },
         {
-            "label": "Lint: Dead domains",
+            "label": "Build: ABP only",
             "type": "shell",
-            "command": "dead-domains-linter -i subscriptions/abpindo.txt --export src/dead_domains.txt",
-            "detail": "Check abpindo.txt for dead domains and export results."
+            "command": "npm run build:abp",
+            "detail": "Build ABP subscriptions only (no DNS formats).",
+            "problemMatcher": []
+        },
+        {
+            "label": "Build: DNS only",
+            "type": "shell",
+            "command": "npm run build:dns",
+            "detail": "Build DNS filter formats only (requires ABP hosts files first).",
+            "problemMatcher": []
+        },
+        {
+            "label": "Format: FOP src/",
+            "type": "shell",
+            "command": "npm run format",
+            "detail": "Run Filter Orderer and Prettifier on src/.",
+            "problemMatcher": []
+        },
+        {
+            "label": "Clean: subscriptions/",
+            "type": "shell",
+            "command": "npm run clean",
+            "detail": "Remove all generated subscription files.",
+            "problemMatcher": []
         }
     ]
 }


### PR DESCRIPTION
## Summary

Replaces the existing 3-task `.vscode/tasks.json` with 8 well-organized tasks that wrap existing `npm run` scripts.

### What changed

| Task | Command | Shortcut |
|------|---------|----------|
| Lint: AGLint | `npm run lint` | Ctrl+Shift+T (default test) |
| Lint: Duplicates | `npm run check:duplicates` | — |
| Check: Lint + Build | `npm run check` | — |
| Build: All subscriptions | `npm run build` | Ctrl+Shift+B (default build) |
| Build: ABP only | `npm run build:abp` | — |
| Build: DNS only | `npm run build:dns` | — |
| Format: FOP src/ | `npm run format` | — |
| Clean: subscriptions/ | `npm run clean` | — |

### Fixes
- **Build task** path was broken (`bash build.sh` → `npm run build`)
- Added missing lint/duplicate-check/format/clean tasks
- All tasks use `npm run` wrappers for cross-platform consistency

### Motivation
Lower the barrier for casual contributors by giving one-click access to all common dev tasks via VSCode's Tasks menu (Ctrl+Shift+P → "Tasks: Run Task").