### PR TITLE
chore: standardise wiki to formal Bahasa Indonesia

### DIFF
--- a/wiki/Dead-Domain-Management.md
+++ b/wiki/Dead-Domain-Management.md
@@ -14,7 +14,7 @@ Tanggal 15:    Impor otomatis (jika belum direview)
 
 ---
 
-## Workflow
+## Alur Kerja
 
 | Workflow | Jadwal | Aksi |
 |----------|--------|------|

--- a/wiki/Filter-Syntax.md
+++ b/wiki/Filter-Syntax.md
@@ -1,4 +1,4 @@
-# Filter Syntax
+# Sintaks Filter
 
 ABPindo mendukung beberapa format sintaks filter tergantung pada software yang digunakan. Halaman ini menjelaskan masing-masing format dan kapan menggunakannya.
 
@@ -114,7 +114,7 @@ local-zone: "iklan.contoh.com" always_nxdomain
 
 ---
 
-## Rekomendasi Format per Use Case
+## Rekomendasi Format Berdasarkan Skenario
 
 | Skenario | Format yang Digunakan |
 |---|---|

--- a/wiki/Filter-Validation.md
+++ b/wiki/Filter-Validation.md
@@ -18,7 +18,7 @@ AGLint memeriksa:
 
 ## Penggunaan
 
-### Command Line
+### Baris Perintah
 
 ```bash
 # Install dependencies (pertama kali saja)

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,4 +1,4 @@
-# Selamat Datang di Wiki ABPindo
+# Beranda Wiki ABPindo
 
 Wiki ini berisi panduan lengkap penggunaan dan pengembangan ABPindo — daftar penapis iklan untuk situs berbahasa Indonesia dan Malaysia.
 
@@ -27,6 +27,8 @@ Wiki ini berisi panduan lengkap penggunaan dan pengembangan ABPindo — daftar p
 
 ## Tautan Cepat
 
+- [🇮🇩 Baca README (Indonesia)](https://github.com/ABPindo/indonesianadblockrules/blob/master/README.md)
+- [🇺🇸 Read README (English)](https://github.com/ABPindo/indonesianadblockrules/blob/master/README.en.md)
 - [Subscribe ABPindo](https://subscribe.adblockplus.org/?location=https://raw.githubusercontent.com/ABPindo/indonesianadblockrules/master/subscriptions/abpindo.txt&title=ABPindo)
 - [GitHub Repository](https://github.com/ABPindo/indonesianadblockrules)
 - [Laporkan Masalah](https://github.com/ABPindo/indonesianadblockrules/issues)

--- a/wiki/Supported-Software.md
+++ b/wiki/Supported-Software.md
@@ -1,65 +1,65 @@
-# Supported Software
+# Perangkat Lunak yang Didukung
 
-Daftar lengkap ekstensi browser, browser, dan software DNS yang kompatibel dengan ABPindo.
+Daftar lengkap ekstensi peramban, peramban, dan perangkat lunak DNS yang kompatibel dengan ABPindo.
 
 ---
 
-## Browser Extension
+## Ekstensi Peramban
 
 Ekstensi yang menggunakan sintaks **Adblock Plus**:
 
-| Ekstensi | Platform | Link |
+| Ekstensi | Platform | Tautan |
 |---|---|---|
-| [uBlock Origin](https://github.com/gorhill/uBlock) | Firefox, Chrome, Edge | [Install](https://github.com/gorhill/uBlock#installation) |
-| [uBlock Origin Lite](https://chromewebstore.google.com/detail/ublock-origin-lite/ddkjiahejlhfcafbddmgiahcphecmpfh) | Chrome, Chromium-based | [Install](https://chromewebstore.google.com/detail/ublock-origin-lite/ddkjiahejlhfcafbddmgiahcphecmpfh) |
-| [AdGuard Browser Extension](https://adguard.com/en/adguard-browser-extension/overview.html) | Firefox, Chrome, Edge, Safari | [Install](https://adguard.com/en/adguard-browser-extension/overview.html) |
-| [Adblock Plus](https://adblockplus.org) | Firefox, Chrome, Edge, Safari | [Install](https://adblockplus.org) |
-| [AdBlock](https://getadblock.com) | Firefox, Chrome, Edge | [Install](https://getadblock.com) |
+| [uBlock Origin](https://github.com/gorhill/uBlock) | Firefox, Chrome, Edge | [Pasang](https://github.com/gorhill/uBlock#installation) |
+| [uBlock Origin Lite](https://chromewebstore.google.com/detail/ublock-origin-lite/ddkjiahejlhfcafbddmgiahcphecmpfh) | Chrome, Chromium-based | [Pasang](https://chromewebstore.google.com/detail/ublock-origin-lite/ddkjiahejlhfcafbddmgiahcphecmpfh) |
+| [AdGuard Browser Extension](https://adguard.com/en/adguard-browser-extension/overview.html) | Firefox, Chrome, Edge, Safari | [Pasang](https://adguard.com/en/adguard-browser-extension/overview.html) |
+| [Adblock Plus](https://adblockplus.org) | Firefox, Chrome, Edge, Safari | [Pasang](https://adblockplus.org) |
+| [AdBlock](https://getadblock.com) | Firefox, Chrome, Edge | [Pasang](https://getadblock.com) |
 
 > **Rekomendasi:** uBlock Origin memberikan performa terbaik dan dukungan sintaks filter paling lengkap.
 
 ---
 
-## Browser dengan Built-in Ad Blocker
+## Peramban dengan Pemblokir Iklan Bawaan
 
-| Browser | Dukungan ABPindo | Cara | Link |
+| Peramban | Dukungan ABPindo | Cara | Tautan |
 |---|---|---|---|
-| [Brave](https://brave.com) | ✅ Native | Tambah via `brave://adblock` — lihat [panduan lengkap](Setup-Browser-Extension#brave-browser-native--tanpa-ekstensi) | [Download](https://brave.com) |
-| [Adblock Browser](https://adblockbrowser.org/) | ✅ Bawaan | ABPindo aktif otomatis saat bahasa Indonesia/Malaysia | [Download](https://adblockbrowser.org/) |
-| [Opera](https://www.opera.com) | ⚠️ Terbatas | Hanya format EasyList basic; scriptlet ABPindo tidak didukung — gunakan ekstensi uBlock Origin | [Download](https://www.opera.com) |
-| [Vivaldi](https://vivaldi.com) | ⚠️ Terbatas | Sama seperti Opera — gunakan ekstensi uBlock Origin untuk hasil terbaik | [Download](https://vivaldi.com) |
+| [Brave](https://brave.com) | ✅ Native | Tambah via `brave://adblock` — lihat [panduan lengkap](Setup-Browser-Extension#brave-browser-native--tanpa-ekstensi) | [Unduh](https://brave.com) |
+| [Adblock Browser](https://adblockbrowser.org/) | ✅ Bawaan | ABPindo aktif otomatis saat bahasa Indonesia/Malaysia | [Unduh](https://adblockbrowser.org/) |
+| [Opera](https://www.opera.com) | ⚠️ Terbatas | Hanya format EasyList basic; scriptlet ABPindo tidak didukung — gunakan ekstensi uBlock Origin | [Unduh](https://www.opera.com) |
+| [Vivaldi](https://vivaldi.com) | ⚠️ Terbatas | Sama seperti Opera — gunakan ekstensi uBlock Origin untuk hasil terbaik | [Unduh](https://vivaldi.com) |
 
 ---
 
-## DNS Server
+## Server DNS
 
-Software server DNS yang mendukung format filter ABPindo:
+Perangkat lunak server DNS yang mendukung format filter ABPindo:
 
-| Software | Format | Link |
+| Perangkat Lunak | Format | Tautan |
 |---|---|---|
 | [AdGuard Home](https://github.com/AdguardTeam/AdGuardHome) | Adblocker-syntax (`\|\|example.com^`) | [GitHub](https://github.com/AdguardTeam/AdGuardHome) |
-| [Pi-Hole](https://pi-hole.net) | Domain / Adblocker-syntax | [Website](https://pi-hole.net) |
-| [Dnsmasq](https://thekelleys.org.uk/dnsmasq/doc.html) | `address=/example.com/0.0.0.0` | [Docs](https://thekelleys.org.uk/dnsmasq/doc.html) |
-| [BIND](https://www.isc.org/bind/) (RPZ) | Response Policy Zone | [Website](https://www.isc.org/bind/) |
+| [Pi-Hole](https://pi-hole.net) | Domain / Adblocker-syntax | [Situs](https://pi-hole.net) |
+| [Dnsmasq](https://thekelleys.org.uk/dnsmasq/doc.html) | `address=/example.com/0.0.0.0` | [Dokumentasi](https://thekelleys.org.uk/dnsmasq/doc.html) |
+| [BIND](https://www.isc.org/bind/) (RPZ) | Response Policy Zone | [Situs](https://www.isc.org/bind/) |
 | [Unbound](https://github.com/NLnetLabs/unbound) | `local-zone` | [GitHub](https://github.com/NLnetLabs/unbound) |
-| [DNSCrypt-proxy](https://dnscrypt.info) | Domain | [Website](https://dnscrypt.info) |
+| [DNSCrypt-proxy](https://dnscrypt.info) | Domain | [Situs](https://dnscrypt.info) |
 
 ---
 
-## Aplikasi Mobile & Network-level Blocker
+## Aplikasi Seluler & Pemblokir Tingkat Jaringan
 
-Software berbasis hosts file, DNS, atau VPN lokal untuk Android:
+Perangkat lunak berbasis hosts file, DNS, atau VPN lokal untuk Android:
 
-| Software | Platform | Format | Keterangan | Link |
+| Perangkat Lunak | Platform | Format | Keterangan | Tautan |
 |---|---|---|---|---|
-| [AdGuard](https://adguard.com) | Android, iOS | Adblocker-syntax | Pilihan terlengkap — blokir di level jaringan tanpa root | [Website](https://adguard.com) |
-| [AdAway](https://adaway.org) | Android (root) | Hosts | Klasik dan ringan, butuh akses root | [Website](https://adaway.org) |
-| [Blokada](https://blokada.org) | Android | Domain | Tanpa root, bekerja via VPN lokal | [Website](https://blokada.org) |
-| [DNS66](https://f-droid.org/packages/org.jak_linux.dns66/) | Android | Domain | Open source, tersedia di F-Droid | [F-Droid](https://f-droid.org/packages/org.jak_linux.dns66/) |
-| [personalDNSfilter](https://zenz-solutions.de/personaldnsfilter/) | Android | Domain | Ringan, berbasis VPN lokal, tersedia di F-Droid | [Website](https://zenz-solutions.de/personaldnsfilter/) |
+| [AdGuard](https://adguard.com) | Android, iOS | Adblocker-syntax | Pilihan terlengkap — blokir di level jaringan tanpa root | [Situs](https://adguard.com) |
+| [AdAway](https://adaway.org) | Android (root) | Hosts | Klasik dan ringan, butuh akses root | [Situs](https://adaway.org) |
+| [Blokada](https://blokada.org) | Android | Domain | Tanpa root, bekerja via VPN lokal | [Situs](https://blokada.org) |
+| [DNS66](https://f-droid.org/packages/org.jak_linux.dns66/) | Android | Domain | Sumber terbuka, tersedia di F-Droid | [F-Droid](https://f-droid.org/packages/org.jak_linux.dns66/) |
+| [personalDNSfilter](https://zenz-solutions.de/personaldnsfilter/) | Android | Domain | Ringan, berbasis VPN lokal, tersedia di F-Droid | [Situs](https://zenz-solutions.de/personaldnsfilter/) |
 
 ---
 
-## Format URL Langganan
+## URL Langganan
 
 Lihat tabel lengkap URL filter untuk setiap format di halaman [Setup: DNS Blocker](Setup-DNS-Blocker).


### PR DESCRIPTION
## Perubahan

Menyelaraskan semua halaman wiki ke bahasa Indonesia formal yang konsisten.

### Perbaikan
- **Filter-Syntax.md**: Judul  → , heading English ke ID
- **Filter-Validation.md**:  → 
- **Dead-Domain-Management.md**:  → 
- **Supported-Software.md**: Seluruh heading English → formal Indonesia, terminologi seragam
- **Home.md**: Judul  → , tambah tautan README dwibahasa

### Status
Semua halaman wiki kini menggunakan bahasa Indonesia formal 100%.